### PR TITLE
more neck stuff

### DIFF
--- a/ch_shrinkwrap/_membrane_mesh.pyx
+++ b/ch_shrinkwrap/_membrane_mesh.pyx
@@ -174,6 +174,8 @@ cdef class MembraneMesh(TriangleMesh):
     cdef public float skip_prob
     cdef object _tree
     cdef public object cg
+    cdef object _points
+    cdef object _sigma
 
     def __init__(self, vertices=None, faces=None, mesh=None, **kwargs):
         TriangleMesh.__init__(self, vertices, faces, mesh, **kwargs)


### PR DESCRIPTION
Work in progress, but adds some useful stuff for making neck/topology decisions. Namely `point_influence` which effectively allows you to visualise the ahfunc weightings and see which areas of the mesh are well constrained by the point data (and the converse).